### PR TITLE
CSE v5.9.1 - Secrets.json Update

### DIFF
--- a/deploy-cse-v5.9.1.sh
+++ b/deploy-cse-v5.9.1.sh
@@ -540,7 +540,7 @@ PORT=$csePort
 USE_SSL=true
 $cseCksUserEnv
 #$cseSecretKeyEnvValue
-SECRET_KEYS_PATH=/app/cse/secrets.json
+#SECRET_KEYS_PATH=/app/cse/secrets.json
 #GOOGLE_APPLICATION_CREDENTIALS=/app/cse/credentials.json
 #SERVICE_ACCOUNT_EMAIL=
 DRIVE_LABELS=false


### PR DESCRIPTION
This update modifies the CSE installation script to comment out the SECRET_KEYS_PATH variable by default in the generated cse.env file.

The SECRET_KEYS_PATH variable, which references /app/cse/secrets.json, is not required for the baseline configuration. Including it causes the container to crash upon startup because the secrets file is initially empty and not needed for standard deployments. Previously, we instructed customers to manually comment out this variable after deployment to prevent crashes.

By commenting this out from the start, we improve the installation experience and prevent unnecessary container failures. Customers who wish to enable key rotation at a later stage can uncomment this variable and properly configure the secrets.json file as part of that future workflow.

This change simplifies the initial deployment process and reduces the chance of user error.