### PR TITLE
feat(cse): enable standalone deployment by removing CKS and Drive Label dependencies

### DIFF
--- a/deploy-cse-v5.9.1.sh
+++ b/deploy-cse-v5.9.1.sh
@@ -539,16 +539,18 @@ $cseCksFqdn
 PORT=$csePort
 USE_SSL=true
 $cseCksUserEnv
-#$cseSecretKeyEnvValue
+$cseSecretKeyEnvValue
 SECRET_KEYS_PATH=/app/cse/secrets.json
+
+#Uncomment the variables and values below to enable CSE Labels
 #GOOGLE_APPLICATION_CREDENTIALS=/app/cse/credentials.json
 #SERVICE_ACCOUNT_EMAIL=
-DRIVE_LABELS=false
-DRIVE_TIME=60
-DRIVE_LABELS_TIME=60
-ADMIN_TIME=60
+#DRIVE_LABELS=false
+#DRIVE_TIME=60
+#DRIVE_LABELS_TIME=60
+#ADMIN_TIME=60
 #LOG_LEVEL=debug
-CONTROL_CENTER_INFO=true
+#CONTROL_CENTER_INFO=true
 
 
 


### PR DESCRIPTION
This update refactors the Virtru CSE deployment script to support **standalone deployments** without relying on the Customer Key Server (CKS) or Google Drive Labels.

### **Key Changes:**

* Removed all CKS-related environment variables and paths (e.g., `$cseCksHmacId`, `$cseCksFqdn`)
* Commented out Google API credential variables and Drive Labels config

- [ ] #Uncomment the variables and values below to enable CSE Labels
- [ ] #GOOGLE_APPLICATION_CREDENTIALS=/app/cse/credentials.json
- [ ] #SERVICE_ACCOUNT_EMAIL=
- [ ] #DRIVE_LABELS=false
- [ ] #DRIVE_TIME=60
- [ ] #DRIVE_LABELS_TIME=60
- [ ] #ADMIN_TIME=60
- [ ] #LOG_LEVEL=debug
- [ ] #CONTROL_CENTER_INFO=true

* Preserved essential values for HMAC auth, JWKS config, and secrets path
* Ensures CSE v5.9.1 runs cleanly without unnecessary dependencies
* Uncommented the secrets value which the secrets path in the run.sh depends on 

- [ ] $cseSecretKeyEnvValue


### **Use Case:**

This update allows CSE to be deployed independently in lightweight or test environments where CKS and label-based classification are not needed.
